### PR TITLE
Resolve the ValueError, could not convert string to float error

### DIFF
--- a/mapbox_location_field/widgets.py
+++ b/mapbox_location_field/widgets.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 
 def parse_tuple_string(tuple_string):
-    return tuple(map(float, tuple_string[1:-1].split(", ")))
+    return tuple(map(float, tuple_string[1:-1].split(",")))
 
 
 class MapInput(TextInput):


### PR DESCRIPTION
The tuple(map(float, tuple_string[1:-1].split(", "))) method tries to split the input by ', ' (a comma followed by a space) but if you are passing the following lat-long tuple string which does not have a space after the comma and therefore the split does not function as expected, resulting in trying to cast the full string containing a tuple pair of coordinates as a float(). which causes the "Resolve the ValueError, could not convert string to float error".