### PR TITLE
changed order of coordinates convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * [Why this?](#why-this)
 * [Live demo](#live-demo)
 * [Compatibility](#compatibility)
-* [Versions >1.4.0 note](#Versions->1.4.0)
+* [Versions >1.4.0 note](#versions-140)
 * [Instalation](#instalation)
 * [Configuration](#configuration)
 * [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 * [Why this?](#why-this)
 * [Live demo](#live-demo)
 * [Compatibility](#compatibility)
- * [Instalation](#instalation)
+* [Versions >1.4.0 note](#Versions->1.4.0)
+* [Instalation](#instalation)
 * [Configuration](#configuration)
 * [Usage](#usage)
     * [PLAIN (non-spatial) db](#plain-database)
@@ -27,6 +28,9 @@
 I was searching for some django location field which uses mapbox and I could use in my project. I didn't find anything which suits my needs in 100% and that is why I created this simple django app. My philosopy was simplicity but I wanted to create complete solution for picking location.
 
 Feel free to open issues, make pull request and request some features or instructions. Let me know if you think it is not flexible enought.
+# Live demo
+Curious how it works and looks like ? See live demo on https://django-mapbox-location-field.herokuapp.com
+Demo app uses [django-bootstrap4](https://github.com/zostera/django-bootstrap4) for a little better looking form fields.
 # Compatibility
 Automatically tested on Travis CI on versions:
 
@@ -39,10 +43,10 @@ PS. Django 1.11 does not support Python 3.7 anymore.
 django-mapbox-location-field support all browsers, which are suported by mapbox gl js. Read more [here](https://docs.mapbox.com/help/troubleshooting/mapbox-browser-support/#mapbox-gl-js)
 #### Databases support
 It should work with every **spatial** and **plain** (non-spatial) database, that works with django and geodjango.
-# Live demo
-Curious how it works and looks like ? See live demo on https://django-mapbox-location-field.herokuapp.com
-Demo app uses [django-bootstrap4](https://github.com/zostera/django-bootstrap4) for a little better looking form fields.
-
+# Versions >1.4.0
+ Since version 1.4.0 the order of coordinates convention has been changed. Now the order is `longitude, latitude`. This change has been caused by support for spatial databases. But more user friendly is order `latitude, longitude`(google maps uses it). That's why coordinates are falsely swapped in frontend and then after POST request in form field are swapped back into `longitude, latitude` order and saved to database.
+ My conclusion is that the location is falsely swapped in fronend and if you create location without our custom form field or just operate on raw model in backend, you will have to use the `longitude, latitude` order.
+ Versions before 1.4.0 always uses `latitude, longitude` order.
 # Instalation
 Using pip:
     `pip install django-mapbox-location-field`

--- a/mapbox_location_field/spatial/forms.py
+++ b/mapbox_location_field/spatial/forms.py
@@ -1,6 +1,5 @@
-from django.contrib.gis.forms import PointField
+from django.contrib.gis.forms import PointField, ValidationError
 from django.contrib.gis.geos import Point
-from django.core.exceptions import ValidationError
 
 from ..forms import parse_location
 from ..widgets import MapInput
@@ -18,7 +17,7 @@ class SpatialLocationField(PointField):
 
     def clean(self, value):
         try:
-            return Point(parse_location(value), srid=4326)
+            return super().clean(value)
         except (ValueError, ValidationError):
             return None
 
@@ -30,4 +29,4 @@ class SpatialLocationField(PointField):
         if isinstance(value, Point):
             return value
 
-        return Point(parse_location(value), srid=4326)
+        return Point(parse_location(value, first_in_order="lat"), srid=4326)

--- a/mapbox_location_field/static/mapbox_location_field/js/map_input.js
+++ b/mapbox_location_field/static/mapbox_location_field/js/map_input.js
@@ -49,13 +49,13 @@ if (!mapboxgl.supported()) {
         function translate_to_string(obj) {
             var lat = obj.lat;
             var lng = obj.lng;
-            return lat + "," + lng
+            return lng + "," + lat
         }
 
         function translate_to_reversed_string(obj) {
             var lat = obj.lat;
             var lng = obj.lng;
-            return lng + "," + lat
+            return lat + "," + lng
         }
 
         function replace_order(array) {
@@ -66,14 +66,14 @@ if (!mapboxgl.supported()) {
         var map = new mapboxgl.Map({
             container: 'secret-id-map-mapbox-location-field',
             style: map_attr_style,
-            center: replace_order(map_attr_center),
+            center: map_attr_center,
             zoom: map_attr_zoom,
         });
         if (input.val()) {
             var marker = new mapboxgl.Marker({draggable: false, color: map_attr_marker_color,});
-            marker.setLngLat(replace_order(map_attr_center))
+            marker.setLngLat(map_attr_center)
                 .addTo(map);
-            input.val(map_attr_center);
+            input.val(replace_order(map_attr_center));
         }
 
         var geocoder = new MapboxGeocoder({
@@ -118,13 +118,13 @@ if (!mapboxgl.supported()) {
 
         map.on("click", function (e) {
             $("div.mapboxgl-marker.mapboxgl-marker-anchor-center").not(".mapboxgl-user-location-dot").remove();
-            input.val(translate_to_string(e.lngLat));
+            input.val(translate_to_reversed_string(e.lngLat));
             var marker = new mapboxgl.Marker({draggable: false, color: map_attr_marker_color,});
             marker.setLngLat(e.lngLat)
                 .addTo(map);
 
 
-            var url = "https://api.mapbox.com/geocoding/v5/mapbox.places/" + translate_to_reversed_string(e.lngLat) + ".json?access_token=" + mapboxgl.accessToken;
+            var url = "https://api.mapbox.com/geocoding/v5/mapbox.places/" + translate_to_string(e.lngLat) + ".json?access_token=" + mapboxgl.accessToken;
             $.get(url, function (data) {
                 reverse_name = data.features[0].place_name;
                 geocoder.setInput(reverse_name);

--- a/mapbox_location_field/tests/test_forms.py
+++ b/mapbox_location_field/tests/test_forms.py
@@ -1,9 +1,11 @@
 from django.contrib.gis.geos import Point
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from mapbox_location_field.forms import LocationField, AddressAutoHiddenField
-from mapbox_location_field.widgets import MapInput, AddressAutoHiddenInput
+from mapbox_location_field.forms import LocationField, AddressAutoHiddenField, reverse_tuple_string
 from mapbox_location_field.spatial.forms import SpatialLocationField
+from mapbox_location_field.widgets import MapInput, AddressAutoHiddenInput
+
 
 class LocationFieldTests(TestCase):
 
@@ -19,6 +21,9 @@ class LocationFieldTests(TestCase):
         field = LocationField(map_attrs={"some": "value", "and some": "cool value"})
         self.assertEqual(field.widget.map_attrs, {"some": "value", "and some": "cool value"})
 
+    def test_clean(self):
+        field = LocationField()
+        self.assertEqual("11,12", field.clean("12, 11"))
 
 class SpatialLocationFieldTests(TestCase):
 
@@ -39,8 +44,8 @@ class SpatialLocationFieldTests(TestCase):
         point = field.clean("12,13")
 
         self.assertIsInstance(point, Point)
-        self.assertEqual(point.x, 12)
-        self.assertEqual(point.y, 13)
+        self.assertEqual(point.x, 13)
+        self.assertEqual(point.y, 12)
 
         point = field.clean("12")
         self.assertIsNone(point)
@@ -56,9 +61,11 @@ class SpatialLocationFieldTests(TestCase):
 
         point = field.to_python("12,13")
         self.assertIsInstance(point, Point)
-        self.assertEqual(point.x, 12)
-        self.assertEqual(point.y, 13)
+        self.assertEqual(point.x, 13)
+        self.assertEqual(point.y, 12)
 
+    def test_reverse_tuple_string(self):
+        self.assertEqual(reverse_tuple_string("1,2"), "2,1")
 
 class AddressAutoHiddenFieldTests(TestCase):
     def test_widget(self):

--- a/mapbox_location_field/tests/test_models.py
+++ b/mapbox_location_field/tests/test_models.py
@@ -13,16 +13,20 @@ class LocationFieldTests(TestCase):
     def assertRaisesValidationError(self, func, *args, **kwargs):
         with self.assertRaises(ValidationError):
             func(*args, **kwargs)
-
     def test_parse_location(self):
         self.assertEqual(parse_location("1,7"), (1, 7))
         self.assertEqual(parse_location("0.5542434352,7.14325463435626543674375"),
                          (0.5542434352, 7.14325463435626543674375))
 
+        self.assertEqual(parse_location("1,7", "lat"), (7, 1))
+        self.assertEqual(parse_location("0.5542434352,7.14325463435626543674375", "lat"),
+                         (7.14325463435626543674375, 0.5542434352))
+
         self.assertRaisesValidationError(parse_location, "1,2,4,7,6")
         self.assertRaisesValidationError(parse_location, "1")
         self.assertRaisesValidationError(parse_location, "1,xD")
         self.assertRaisesValidationError(parse_location, "xD,1")
+        self.assertRaisesValidationError(parse_location, "1,2", "alfhjksd")
 
     def test_LocationField(self):
         instance = LocationField()

--- a/mapbox_location_field/tests/test_widgets.py
+++ b/mapbox_location_field/tests/test_widgets.py
@@ -72,7 +72,7 @@ class MapInputTests(TestCase):
         settings.MAPBOX_KEY = "MY_COOL_MAPBOX_KEY"
 
         expected_js_list = ["var map_attr_style = 'mapbox://styles/mapbox/outdoors-v11'", "var map_attr_zoom = '13'",
-                            "var map_attr_center = [51.106715, 17.031645]", "var map_attr_cursor_style = 'pointer'",
+                            "var map_attr_center = [17.031645, 51.106715]", "var map_attr_cursor_style = 'pointer'",
                             "var map_attr_marker_color = 'red'", "var map_attr_rotate = false",
                             "var map_attr_geocoder = true",
                             "var map_attr_fullscreen_button = true", "var map_attr_navigation_buttons = true",
@@ -145,7 +145,7 @@ class MapInputTests(TestCase):
         self.equality_of_random_javascript(js[:-9], ["mapboxgl.accessToken = 'MY_COOL_MAPBOX_KEY'",
                                                      "var map_attr_style = 'mapbox://styles/mapbox/outdoors-v11'",
                                                      "var map_attr_zoom = '13'",
-                                                     'var map_attr_center = [51.106715, 17.031645]',
+                                                     'var map_attr_center = [17.031645, 51.106715]',
                                                      "var map_attr_cursor_style = 'pointer'",
                                                      "var map_attr_marker_color = 'red'", 'var map_attr_rotate = false',
                                                      'var map_attr_geocoder = true',

--- a/mapbox_location_field/widgets.py
+++ b/mapbox_location_field/widgets.py
@@ -60,7 +60,7 @@ class MapInput(TextInput):
         default_map_attrs = {
             "style": "mapbox://styles/mapbox/outdoors-v11",
             "zoom": 13,
-            "center": [51.106715, 17.031645],
+            "center": [17.031645, 51.106715],
             "cursor_style": 'pointer',
             "marker_color": "red",
             "rotate": False,


### PR DESCRIPTION
The order of coordinates convention has been changed. Now the order is `longitude, latitude`. This change has been caused by support for spatial databases. But more user friendly is order `latitude, longitude`(google maps uses it). That's why coordinates are falsely swapped in frontend and then after POST request in form field are swapped back into `longitude, latitude` order and saved to database. My conclusion is that the location is falsely swapped in fronend and if you create location without our custom form field or just operate on raw model in backend, you will have to use the `longitude, latitude` order.